### PR TITLE
Add use typing

### DIFF
--- a/tg_gui_core/__init__.py
+++ b/tg_gui_core/__init__.py
@@ -43,13 +43,15 @@ from ._shared import (
     uid,
     UID,
     clamp,
+    isoncircuitpython,
+    enum_compat,
+    USE_TYPING,
 )
 
 from .base import (
     Widget,
     color,
     Color,
-    isoncircuitpython,
     singleinstance,
     application,
     NestingError,

--- a/tg_gui_core/_shared.py
+++ b/tg_gui_core/_shared.py
@@ -30,6 +30,7 @@ def enum_compat(cls: type) -> type:
 # --- platform optimization ---
 if sys.implementation.name in ("circuitpython", "micropython"):
     isoncircuitpython = lambda: True
+    USE_TYPING = False
 
     from . import typing_bypass
     from . import enum_bypass
@@ -39,12 +40,8 @@ if sys.implementation.name in ("circuitpython", "micropython"):
 
     enum_compat = enum_bypass.enum_compat
 else:
+    USE_TYPING = True
     isoncircuitpython = lambda: False
-    from typing import Type
-
-    # TODO: change this for USE_TYPING
-    # FOR NOW:
-    from . import typing_bypass
 
 
 # --- unique ids ---

--- a/tg_gui_core/base.py
+++ b/tg_gui_core/base.py
@@ -29,14 +29,17 @@ from .dimension_specifiers import *
 
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
+if USE_TYPING:
 
     from typing import *
 
-    from .root_widget import Root
-
     class Identifiable(Protocol):
         _id_: UID
+
+
+if TYPE_CHECKING:
+
+    from .root_widget import Root
 
 
 T = TypeVar("T")

--- a/tg_gui_core/dimension_specifiers.py
+++ b/tg_gui_core/dimension_specifiers.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-from ._shared import enum_compat, isoncircuitpython
+from ._shared import enum_compat
 from enum import Enum, auto
 
 from typing import TYPE_CHECKING

--- a/tg_gui_core/enum_bypass.py
+++ b/tg_gui_core/enum_bypass.py
@@ -30,7 +30,7 @@ class Enum:
     def __new__(cls, *_, **__):
         raise TypeError(
             f"Cannot make Enum '{cls.__name__}' instances on circuitpython, "
-            "decorate the class with @enum_compat"
+            + "decorate the class with @enum_compat"
         )
 
     def __init__(self, name: str, autoid: int):

--- a/tg_gui_core/stateful.py
+++ b/tg_gui_core/stateful.py
@@ -22,11 +22,11 @@
 
 from __future__ import annotations
 
-from ._shared import uid, UID, isoncircuitpython
+from ._shared import uid, UID, USE_TYPING
 
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
+if USE_TYPING:
     from typing import *
 
 

--- a/tg_gui_platform/_platform_impls/displayio_impl/event_loop.py
+++ b/tg_gui_platform/_platform_impls/displayio_impl/event_loop.py
@@ -23,63 +23,61 @@
 from __future__ import annotations
 
 
-from tg_gui_core import Widget, isoncircuitpython, UID
+from tg_gui_core import Widget, UID
 import time
 from time import monotonic_ns
 from micropython import const  # type: ignore
 
 _do_nothing = lambda: None
 
+from typing import TYPE_CHECKING
 
-if not isoncircuitpython():
+if TYPE_CHECKING:
     from typing import Callable, Optional, Protocol
 
     Time = int
     # --- known import fail ---
-    try:  #  typing import hack
-        Point = tuple[int, int]
-        # from .screen import Screen
+    Point = tuple[int, int]
+    # from .screen import Screen
 
-        class Selectable(Widget, Protocol):  # type: ignore
-            def _select_(self) -> None:
-                ...
+    class Selectable(Widget, Protocol):  # type: ignore
+        def _select_(self) -> None:
+            ...
 
-            def _deselect_(self) -> None:
-                ...
+        def _deselect_(self) -> None:
+            ...
 
-        class Pressable(Widget, Protocol):  # type: ignore
-            def _action_(self) -> None:
-                ...
+    class Pressable(Widget, Protocol):  # type: ignore
+        def _action_(self) -> None:
+            ...
 
-        class Updateable(Widget, Protocol):  # type: ignore
-            def _start_update_(self, coord: Point) -> None:
-                ...
+    class Updateable(Widget, Protocol):  # type: ignore
+        def _start_update_(self, coord: Point) -> None:
+            ...
 
-            def _continue_update_(self, coord: Point) -> None:
-                ...
+        def _continue_update_(self, coord: Point) -> None:
+            ...
 
-            def _end_update_(self, coord: Point) -> None:
-                ...
+        def _end_update_(self, coord: Point) -> None:
+            ...
 
-        class EventLoop(Protocol):
-            def wastocuhed(self) -> bool:
-                ...
+    class EventLoop(Protocol):
+        def wastocuhed(self) -> bool:
+            ...
 
-            @property
-            def touchedcoord(self) -> Optional[Point]:
-                ...
+        @property
+        def touchedcoord(self) -> Optional[Point]:
+            ...
 
-            def loop(self) -> None:
-                ...
+        def loop(self) -> None:
+            ...
 
-            def add_widget_if_needed(self, widget: Widget):
-                ...
+        def add_widget_if_needed(self, widget: Widget):
+            ...
 
-            def remove_widget_if_present(self, widget: Widget):
-                ...
+        def remove_widget_if_present(self, widget: Widget):
+            ...
 
-    except:
-        pass
 
 else:
     EventLoop = object  # type:ignore

--- a/tg_gui_platform/_platform_impls/displayio_impl/prelude.py
+++ b/tg_gui_platform/_platform_impls/displayio_impl/prelude.py
@@ -22,17 +22,17 @@
 
 from __future__ import annotations
 
-from tg_gui_core import Widget, Root, isoncircuitpython
+from tg_gui_core import Widget, Root, isoncircuitpython, USE_TYPING
 from .screen import Screen
 from .event_loop import EventLoop, SinglePointEventLoop
 
-if not isoncircuitpython():
+from typing import TYPE_CHECKING
+
+if USE_TYPING:
     from typing import Callable
 
-    if isoncircuitpython():  # typing import hack
-        from tg_gui_core import Theme
-else:
-    pass
+if TYPE_CHECKING:
+    from tg_gui_core import Theme
 
 from displayio import Display
 


### PR DESCRIPTION
switch from using `not isoncircuitpython()` to a tg_gui provided constant `USE_TYPING` which not only makes it clear but is distinct from `TYPE_CHECKING`.

so now, use `TYPE_CHECKING` for circular imports and `USE_TYPING` for type imports