### PR TITLE
Improve typing bypass

### DIFF
--- a/tg_gui_core/stateful.py
+++ b/tg_gui_core/stateful.py
@@ -29,11 +29,6 @@ from typing import TYPE_CHECKING
 if USE_TYPING:
     from typing import *
 
-
-T = TypeVar("T")
-S = TypeVar("S")
-
-if TYPE_CHECKING:
     # Handler = Callable[[T], Any]
     Handler = Callable[..., Any]
     # DerivedHandler = Callable[..., Any]
@@ -60,8 +55,10 @@ if TYPE_CHECKING:
 else:
     from .typing_bypass import Bypass
 
-    Bindable = Bypass("Bindable", [object])
-    Identifiable = object
+    Bindable = Bypass("Bindable", type)
+
+T = TypeVar("T")
+S = TypeVar("S")
 
 
 def _not(obj: object) -> bool:

--- a/tg_gui_core/typing_bypass.py
+++ b/tg_gui_core/typing_bypass.py
@@ -2,18 +2,41 @@ import sys
 
 TYPE_CHECKING = False
 
+try:
+    from typing import *
+
+    raise RuntimeError
+except ImportError:
+    pass
+except RuntimeError:
+    raise ImportError(
+        "tried importing typing _bypass when the typing module is avaible "
+        + "(You should not need to use tg_gui_core.typing_bypass in "
+        + "a context where the typing module can be imported)"
+    )
+
 
 class Bypass:
-    def __init__(self, __name: str, ___getitem=[], **attrs: object) -> None:
+
+    _getitem_return_value___: object
+
+    def __init__(
+        self,
+        __name: str,
+        ___getitem: list[object] | Type[type] = [],
+        **attrs: object,
+    ) -> None:
         self.__name = __name
 
-        assert isinstance(___getitem, list) and (
-            len(___getitem) in {0, 1}
-        ), f"expected an empty list or list containing one item, got {___getitem}"
+        assert (
+            ___getitem is type
+            or isinstance(___getitem, list)
+            and (len(___getitem) in {0, 1})
+        ), f"expected the `type` object, an empty list, a list containing one item, got {___getitem}"
 
-        if len(___getitem) == 0:
-            pass
-        elif len(___getitem) == 1:
+        if ___getitem is type:
+            self._getitem_return_value___ = type(__name + "Bypass", (), {})
+        elif isinstance(___getitem, list) and len(___getitem) == 1:
             self._getitem_return_value___ = ___getitem[0]
 
         for attr, obj in attrs.items():
@@ -36,5 +59,5 @@ sys.modules["__future__"] = Bypass("__future__", [], annotations=None)  # type: 
 # patch in things the gramar cannot get rid of
 import builtins
 
-builtins.Generic = Generic = Bypass("Generic", [object])  # type: ignore
+builtins.Generic = Generic = Bypass("Generic", type)  # type: ignore
 builtins.TypeVar = TypeVar = lambda *_, **__: object  # type: ignore


### PR DESCRIPTION
Modify the `Bypass` class in typing_bypass so multiple typing bypasses can be combined in the same class signature. This does mean new class instances need to be created at runtime.

ex:
```python
from tg_gui_core.typing_bypass import Bypass
Generic = Bypass('Generic", type)
Bindable = Bypass('Bindable", type)

class Foo(Generic[T], Bindable[T]):
    ....
```