### PR TITLE
auto format classes to replace `@themedwidget` and `@layoutwidget` with not decoration

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,6 @@ import sys
 import time
 
 # import micropython
-
 # micropython.opt_level(3)
 
 if sys.implementation.name in {"circuitpython", "micropython"}:
@@ -11,10 +10,6 @@ if sys.implementation.name in {"circuitpython", "micropython"}:
 
 from tg_gui.prelude import *
 
-
-# from tg_gui_core._step_print_debugging_ import use_step_print_debugging
-
-# use_step_print_debugging(True)
 
 if isoncircuitpython():
     gc.collect()

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ if sys.implementation.name in {"circuitpython", "micropython"}:
 
 from tg_gui.prelude import *
 
+
 # from tg_gui_core._step_print_debugging_ import use_step_print_debugging
 
 # use_step_print_debugging(True)
@@ -22,7 +23,6 @@ if isoncircuitpython():
 
 @main(screen := default.screen())
 @application
-@layoutwidget
 class Test(View):
 
     _theme_ = Theme(

--- a/tg_gui/view.py
+++ b/tg_gui/view.py
@@ -38,5 +38,4 @@ class View(Layout):
     body: ClassVar[Callable[[], Widget]]
 
     def _layout_(self):
-        print("<^1>", self)
         body = self.body(center, self.dims)

--- a/tg_gui/view.py
+++ b/tg_gui/view.py
@@ -23,7 +23,7 @@
 from __future__ import annotations
 
 
-from tg_gui_core import center, declarable, Widget
+from tg_gui_core import center, Widget
 from tg_gui_core.layout import Layout
 from tg_gui_core.widget_builder import WidgetBuilder, _widget_builder_cls_format
 
@@ -33,22 +33,10 @@ if TYPE_CHECKING:
     from typing import *
 
 
-@declarable
 class View(Layout):
 
     body: ClassVar[Callable[[], Widget]]
 
-    def __new__(cls, *args, **kwargs):
-        assert (
-            cls is not View
-        ), f"View is an abstract class, {cls} cannot be instantiated"
-        assert hasattr(cls, "body"), "View must have a body widget builder"
-
-        # TODO: make this a better check
-        if not isinstance(cls.body, WidgetBuilder):
-            _widget_builder_cls_format(cls)
-
-        return super().__new__(cls)
-
     def _layout_(self):
-        self.body(center, self.dims)
+        print("<^1>", self)
+        body = self.body(center, self.dims)

--- a/tg_gui_core/__init__.py
+++ b/tg_gui_core/__init__.py
@@ -27,7 +27,7 @@ import sys
 # -- start exposed api imports ---
 
 # base classes and application environment
-from ._platform_support import (
+from ._implementation_support import (
     guiexit,
     isoncircuitpython,
     enum_compat,
@@ -42,7 +42,7 @@ from .base import (
 )
 
 from .container import Container
-from .layout import Layout, layoutwidget
+from .layout import Layout
 
 from .stateful import (
     State,
@@ -80,10 +80,10 @@ from .dimension_specifiers import (
 # --- std lib and impl tool ---
 
 # classes and functions for making widget classes
-from ._platform_support import enum_compat
+from ._implementation_support import enum_compat
 from .base import uid, UID, _Screen_
-from .container import declarable, isdeclarable
 from .root_widget import Root
+from .widget_builder import Declarable
 from .styled_widget import StyledWidget, align, Color, color
 from .theming import Theme, themedwidget
 

--- a/tg_gui_core/_implementation_support.py
+++ b/tg_gui_core/_implementation_support.py
@@ -50,8 +50,7 @@ if sys.implementation.name == "circuitpython":
     isoncpython = lambda: False
     enum_compat = _cpython_bypass.enum_compat
 
-    # cls_unique_id = lambda cls: hash(f":{cls.__module__}.{cls.__name__}")
-    cls_unique_id = lambda cls: (f":{cls.__module__}.{cls.__name__}")
+    cls_unique_id = lambda cls: hash(f":{cls.__module__}.{cls.__name__}")
 
 elif sys.implementation.name == "cpython":
     from sys import exit as guiexit
@@ -70,5 +69,3 @@ else:
         + "please open an issue at https://github.com/TG-Techie/tg-gui/issues/new?"
         + "title=unsupported%20python%20implementation%3A%20{sys.implementation.name}"
     )
-
-cls_unique_id = lambda cls: (f":{cls.__module__}.{cls.__name__}")

--- a/tg_gui_core/_implementation_support.py
+++ b/tg_gui_core/_implementation_support.py
@@ -31,6 +31,12 @@ def enum_compat(cls):
 
 # --- platform optimization ---
 if sys.implementation.name == "circuitpython":
+    if sys.implementation.version < (7, 2):
+        raise RuntimeError(
+            "CircuitPython version 7.2.0 or higher is required. "
+            + f"running on {'.'.join(sys.implementation.version)}"
+        )
+
     from . import _cpython_bypass
 
     sys.modules["typing"] = _cpython_bypass  # type: ignore
@@ -44,6 +50,9 @@ if sys.implementation.name == "circuitpython":
     isoncpython = lambda: False
     enum_compat = _cpython_bypass.enum_compat
 
+    # cls_unique_id = lambda cls: hash(f":{cls.__module__}.{cls.__name__}")
+    cls_unique_id = lambda cls: (f":{cls.__module__}.{cls.__name__}")
+
 elif sys.implementation.name == "cpython":
     from sys import exit as guiexit
 
@@ -53,9 +62,13 @@ elif sys.implementation.name == "cpython":
     enum_compat = lambda cls: cls
 
     from types import FunctionType, MethodType
+
+    cls_unique_id = id
 else:
     raise Exception(
         f"unsupported python implementation: {sys.implementation.name}, "
         + "please open an issue at https://github.com/TG-Techie/tg-gui/issues/new?"
         + "title=unsupported%20python%20implementation%3A%20{sys.implementation.name}"
     )
+
+cls_unique_id = lambda cls: (f":{cls.__module__}.{cls.__name__}")

--- a/tg_gui_core/_step_print_debugging_.py
+++ b/tg_gui_core/_step_print_debugging_.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/tg_gui_core/base.py
+++ b/tg_gui_core/base.py
@@ -320,7 +320,7 @@ class Widget:  # type: ignore
         def __new__(cls, *args, **kwargs):
 
             if not cls._is_subclass_formatted():
-                cls._fmt_on_subclass_init_(expected_id)
+                cls._format_subclass_on_init()
             return object.__new__(cls)
 
     @classmethod
@@ -351,7 +351,7 @@ class Widget:  # type: ignore
         while curcls is not object:
             if "_subclass_format_" in curcls.__dict__:
                 order.append(curcls)
-            curcls = curcls.__base__
+            curcls = curcls.__bases__[0]
         else:
             for basecls in reversed(order):
                 basecls._subclass_format_(cls)

--- a/tg_gui_core/base.py
+++ b/tg_gui_core/base.py
@@ -597,4 +597,3 @@ class Widget:  # type: ignore
 
 
 Widget._format_subclass_on_init()
-print(f"{Widget._subcls_gui_id_=}")

--- a/tg_gui_core/container.py
+++ b/tg_gui_core/container.py
@@ -31,42 +31,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Callable, Type, ClassVar
-    from .theming import ThemeDict
-
-
-if TYPE_CHECKING:
-    # this function is a no-op for typing transparancy when using mypy but is overwritten below.
-    # DO NOT add typing annotations or doc strings to this function.
-    def declarable(cls):
-        return cls
-
-else:
-
-    def declarable(cls: Type["Widget"]) -> Type["Widget"]:
-        """
-        dcecorator to mark that a contianer is declarable (like layout or Pages).
-        this is used for attr_specs to finf the referenced self in `self.blah`
-        """
-        assert isinstance(cls, type), f"can only decorate classes"
-        assert issubclass(
-            cls, Container
-        ), f"{cls} does not subclass Container, it must to be @declarable"
-        cls._declarable_ = True
-
-        return cls
-
-
-def isdeclarable(obj: object) -> bool:
-    assert isinstance(obj, type) and issubclass(obj, Widget), (
-        "can only test sublcasses of the Widget class" + ", got type {obj}"
-    )
-
-    return (
-        isinstance(obj, type)
-        and issubclass(obj, Container)
-        and hasattr(obj, "_declarable_")
-        and obj._declarable_  # type: ignore
-    )
+    from .theming import ThemeCompatible
 
 
 class Container(Widget):
@@ -77,9 +42,9 @@ class Container(Widget):
     _is_app_: ClassVar[bool] = False
     _declarable_: bool | ClassVar[bool] = False
 
-    _theme_: None | Theme | ThemeDict = None
+    _theme_: None | ThemeCompatible = None
 
-    def __init__(self, theme: Theme | ThemeDict | None = None) -> None:
+    def __init__(self, theme: ThemeCompatible | None = None) -> None:
         super().__init__(_margin_=0)
 
         if isinstance(theme, dict) and __debug__:

--- a/tg_gui_core/dimension_specifiers.py
+++ b/tg_gui_core/dimension_specifiers.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-from ._platform_support import enum_compat, use_typing
+from ._implementation_support import enum_compat, use_typing
 from enum import Enum, auto
 
 from typing import TYPE_CHECKING, Union

--- a/tg_gui_core/position_specifiers.py
+++ b/tg_gui_core/position_specifiers.py
@@ -22,7 +22,7 @@
 
 from __future__ import annotations
 
-from ._platform_support import use_typing
+from ._implementation_support import use_typing
 
 from typing import TYPE_CHECKING, Union
 

--- a/tg_gui_core/stateful.py
+++ b/tg_gui_core/stateful.py
@@ -22,7 +22,7 @@
 
 from __future__ import annotations
 
-from ._platform_support import use_typing
+from ._implementation_support import use_typing
 from .base import uid, UID
 
 from typing import TYPE_CHECKING

--- a/tg_gui_core/styled_widget.py
+++ b/tg_gui_core/styled_widget.py
@@ -23,7 +23,7 @@
 from __future__ import annotations
 
 from .base import Widget
-from ._platform_support import enum_compat, isoncircuitpython
+from ._implementation_support import enum_compat, isoncircuitpython
 from .stateful import State
 
 # from .specifiers import specify, Specifier

--- a/tg_gui_core/theming.py
+++ b/tg_gui_core/theming.py
@@ -22,7 +22,7 @@
 
 from __future__ import annotations
 
-from ._platform_support import use_typing, isoncircuitpython
+from ._implementation_support import use_typing, isoncircuitpython
 from .base import uid, UID, Widget
 from .stateful import State
 
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from .stateful import State
 
     ThemeAttrsDict = Dict["ThemedAttribute", Any]
-    ThemeDict = dict[StyledWidget, ThemeAttrsDict]
+    ThemeCompatible = Union["Theme", dict[StyledWidget, ThemeAttrsDict]]
 
 
 _NotFound = object()
@@ -100,7 +100,7 @@ else:
 class ThemedAttribute(Generic[T]):
     isbuildattr: ClassVar[bool]
 
-    if __debug__ and not TYPE_CHECKING:
+    if __debug__:
 
         def __new__(cls: Type[ThemedAttribute], *_, **__) -> ThemedAttribute:
             assert (
@@ -205,6 +205,12 @@ else:
 
 class Theme(dict):
     _themed_widget_types_: ClassVar[set[Type[StyledWidget]]] = set()
+
+    # optimization for memory usage
+    if not __debug__:
+
+        def __new__(self, specs, *, _debug_name_: str | None = None):
+            return specs
 
     def __init__(self, specs, *, _debug_name_: str | None = None) -> None:
         self._id_ = uid()

--- a/tg_gui_core/widget_builder.py
+++ b/tg_gui_core/widget_builder.py
@@ -22,7 +22,7 @@
 
 from __future__ import annotations
 
-from ._platform_support import isoncpython, isoncircuitpython
+from ._implementation_support import isoncpython, isoncircuitpython
 from .base import UID, uid, Widget, _MISSING
 from .container import Container
 from .stateful import State
@@ -34,7 +34,7 @@ _W = TypeVar("_W", bound=Widget)
 _C = TypeVar("_C", bound=Container)
 
 if TYPE_CHECKING:
-    from typing import Callable, Type, Any
+    from typing import Callable, Type, Any, ClassVar
 
     from .position_specifiers import PosSpec
     from .dimension_specifiers import DimSpec
@@ -282,9 +282,6 @@ class WidgetBuilder(Generic[_C, _W]):
         return lambda *, __build=self.build, __owner=owner: __build(__owner)
 
     def build(self, owner: _C) -> _W:
-        """
-        This is called when the descriptor is accessed.
-        """
 
         # get the proxy objects for the build process to use
         # however, if the owner has them cached, use thos isead of making new proxies
@@ -315,3 +312,11 @@ class WidgetBuilder(Generic[_C, _W]):
         del app_proxy
 
         return widget
+
+
+class Declarable(Container):
+    _declarable_: ClassVar[bool] = True
+
+    @classmethod
+    def _subclass_format_(cls: Type[Declarable], subcls: Type[Declarable]) -> str:
+        _widget_builder_cls_format(subcls)

--- a/tg_gui_core/widget_builder.py
+++ b/tg_gui_core/widget_builder.py
@@ -130,7 +130,7 @@ class _BuildProxy(Generic[_W]):
         self._debug = repr(" debug:" + _debug) if _debug and __debug__ else ""
 
     def __repr__(self):
-        return f"<{type(self).__name__}: {self._id_}{self._debug}>"
+        return f"<{type(self).__name__}: {self._id_} {self._proxied} {self._debug}>"
 
     def _close_build_(self):
         # close any build objects


### PR DESCRIPTION
the behavior associated with `@themedwidget`, `@layoutwidget`, etc is now  moved into `_subclass_format_` classmethods. on cpython it is performed with the [`def __init_subclass__`](https://docs.python.org/3/reference/datamodel.html?highlight=__init_subclass__) hook to run the format sugar / backend setup provided by themed widget and the like.

on circuitpython these methods are run the first time  a class is inited (via the __new__ method) 